### PR TITLE
Fix time space when chatting

### DIFF
--- a/tutor/matching/templates/matching/post_detail.html
+++ b/tutor/matching/templates/matching/post_detail.html
@@ -350,7 +350,7 @@
         inner_msg.className = "sent_msg";
         var msg_time = document.createElement("span");
         msg_time.className = "sent_time_date";
-        msg_time.innerHTML += data['date'];
+        msg_time.innerHTML += "&nbsp;" + data['date'] + "&nbsp;";
         var msg_content = document.createElement("div");
         msg_content.className = "msg_box";
         msg_content.className += " msg_content";
@@ -398,7 +398,7 @@
         received_with_msg.innerHTML += makeUrl(data['content']);
         var received_time_date = document.createElement("span");
         received_time_date.className = "received_time_date";
-        received_time_date.innerHTML += data['date'];
+        received_time_date.innerHTML += "&nbsp;" + data['date'] + "&nbsp;";
         received_msg.append(received_name);
         received_msg.append(received_with_msg);
         received_msg.append(received_time_date);

--- a/tutor/matching/templates/matching/session_detail.html
+++ b/tutor/matching/templates/matching/session_detail.html
@@ -354,7 +354,7 @@
         inner_msg.className = "sent_msg";
         var msg_time = document.createElement("span");
         msg_time.className = "sent_time_date";
-        msg_time.innerHTML += data['date'];
+        msg_time.innerHTML += "&nbsp;" + data['date'] + "&nbsp;";
         var msg_content = document.createElement("div");
         msg_content.className = "msg_box";
         msg_content.className += " msg_content";
@@ -402,7 +402,7 @@
         received_with_msg.innerHTML += makeUrl(data['content']);
         var received_time_date = document.createElement("span");
         received_time_date.className = "received_time_date";
-        received_time_date.innerHTML += data['date'];
+        received_time_date.innerHTML += "&nbsp;" + data['date'] + "&nbsp;";
         received_msg.append(received_name);
         received_msg.append(received_with_msg);
         received_msg.append(received_time_date);


### PR DESCRIPTION
When sending and receiving chat messages in real time
the spacing between the date time and message content
was not set right.
Therefore add a space between the two to have a consistent
distance between the two.