### PR TITLE
Fix time space when chatting

### DIFF
--- a/tutor/matching/templates/matching/post_detail.html
+++ b/tutor/matching/templates/matching/post_detail.html
@@ -311,8 +311,8 @@
   var storage = document.getElementById("msg_history");
   storage.scrollTop = storage.scrollHeight;
 
-  // const websocket = new WebSocket('wss://' + window.location.host + ':8443/ws/post/' + "{{post.pk}}" + '/');
-  const websocket = new WebSocket('ws://' + window.location.host + '/ws/post/' + "{{post.pk}}" + '/');
+  const websocket = new WebSocket('wss://' + window.location.host + ':8443/ws/post/' + "{{post.pk}}" + '/');
+  // const websocket = new WebSocket('ws://' + window.location.host + '/ws/post/' + "{{post.pk}}" + '/');
 
   websocket.onmessage = function(e) {
       const data = JSON.parse(e.data);

--- a/tutor/matching/templates/matching/session_detail.html
+++ b/tutor/matching/templates/matching/session_detail.html
@@ -312,8 +312,8 @@
   var storage = document.getElementById("msg_history");
   storage.scrollTop = storage.scrollHeight;
 
-  // const websocket = new WebSocket('wss://' + window.location.host + ':8443/ws/session/' + "{{pk}}" + '/');
-  const websocket = new WebSocket('ws://' + window.location.host + '/ws/session/' + "{{pk}}" + '/');
+  const websocket = new WebSocket('wss://' + window.location.host + ':8443/ws/session/' + "{{pk}}" + '/');
+  // const websocket = new WebSocket('ws://' + window.location.host + '/ws/session/' + "{{pk}}" + '/');
 
   websocket.onmessage = function(e) {
     const data = JSON.parse(e.data);

--- a/tutor/matching/templates/matching/waiting_room.html
+++ b/tutor/matching/templates/matching/waiting_room.html
@@ -66,8 +66,8 @@
 </div>
 
 <script>
-  // const websocket = new WebSocket('wss://' + window.location.host + ':8443/ws/session/' + "{{pk}}" + '/');
-  const websocket = new WebSocket('ws://' + window.location.host + '/ws/session/' + "{{pk}}" + '/');
+  const websocket = new WebSocket('wss://' + window.location.host + ':8443/ws/session/' + "{{pk}}" + '/');
+  // const websocket = new WebSocket('ws://' + window.location.host + '/ws/session/' + "{{pk}}" + '/');
 
   websocket.onmessage = function(e){
     const data = JSON.parse(e.data);

--- a/tutor/tutor/settings.py
+++ b/tutor/tutor/settings.py
@@ -161,8 +161,8 @@ CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
-            # "hosts": [("redis://:AledmaThakd@172.17.0.2:6379/0")],
-            "hosts": [('127.0.0.1', 6379)],
+            "hosts": [("redis://:AledmaThakd@172.17.0.2:6379/0")],
+            # "hosts": [('127.0.0.1', 6379)],
         },
     },
 }


### PR DESCRIPTION
When sending and receiving chat messages in real time
the spacing between the date time and message content
was not set right.
Therefore add a space between the two to have a consistent
distance between the two.