### PR TITLE
Prevent any chat when Websocket is closing - resolve #310

### DIFF
--- a/tutor/matching/templates/matching/post_detail.html
+++ b/tutor/matching/templates/matching/post_detail.html
@@ -492,6 +492,7 @@
   websocket.onclose = function(e){
     console.error('Chat socket closed unexpectedly');
     document.getElementById('lost_connection').style.visibility = "visible";
+    document.getElementById("msg_send_btn").disabled = true;
   };
 
   function sendMessage(){

--- a/tutor/matching/templates/matching/session_detail.html
+++ b/tutor/matching/templates/matching/session_detail.html
@@ -521,6 +521,7 @@
     console.error('Chat socket closed unexpectedly');
     document.getElementById("start_new_tutoring").disabled = true;
     document.getElementById('lost_connection').style.visibility = "visible";
+    document.getElementById("msg_send_btn").disabled = true;
   };
 
   function sendMessage(){


### PR DESCRIPTION
It is undesirable to enter any chat when real time chat is not
available. Resolved by disabling the send button when websocket is
closing.