### PR TITLE
Session Detail change

### DIFF
--- a/tutor/matching/templates/matching/session_detail.html
+++ b/tutor/matching/templates/matching/session_detail.html
@@ -49,7 +49,11 @@
         </tr>
         <tr>
           <td class="text-center text-nowrap align-middle"><b>장소</b></td>
+          {% if session.location is not None%}
           <td class="text-center text-nowrap align-middle">{{session.location}}</td>
+          {% else %}
+          <td class="text-center text-nowrap align-middle">미정</td>
+          {% endif %}
         </tr>
         <tr>
           <td class="text-center text-nowrap align-middle"><b>시작 시간</b></td>
@@ -508,7 +512,12 @@
     } else if (data['type'] == "waiting_tutee_out"){
       // alert("OUT");
       let waiting_tutee = document.getElementById("waiting_tutee");
-      waiting_tutee.innerHTML = parseInt(waiting_tutee.innerHTML) - 1;
+      let waiting_tutee_value = parseInt(waiting_tutee.innerHTML) - 1;
+
+      if(waiting_tutee_value < 0){
+          waiting_tutee_value = 0;
+      }
+      waiting_tutee.innerHTML = waiting_tutee_value;
     }
 
     if(at_bottom){


### PR DESCRIPTION
In session detail page, when there is no place information, 'None' is
printed. Instead, '미정' is printed.