### PR TITLE
fix #319

### DIFF
--- a/tutor/matching/forms.py
+++ b/tutor/matching/forms.py
@@ -73,12 +73,14 @@ class TutorSessionForm(forms.ModelForm):
         self.fields['start_time'].widget = DateTimePicker(
             options={
                 'defaultDate': start_time_str,
+                'vertical': 'top',
             }
         )
 
         self.fields['expected_fin_time'].widget = DateTimePicker(
             options={
                 'defaultDate': end_time_str,
+                'vertical': 'top',
             }
         )
 


### PR DESCRIPTION
made the vertical position of datetime picker widget to always be on top