### PR TITLE
FIX 튜티의 경우 닉네임 수정이 안보이는 에러 수정

### DIFF
--- a/tutor/matching/templates/matching/mypage_post.html
+++ b/tutor/matching/templates/matching/mypage_post.html
@@ -47,10 +47,10 @@
     <li class="nav-item">
       <a class="nav-link" href="{% url 'matching:mypage_tutor_session' %}">진행한 TA 세션</a>
     </li>
+    {% endif %}
     <li class="nav-item">
       <a class="nav-link" href="{% url 'matching:mypage_profile' user.pk %}">닉네임 수정</a>
     </li>
-    {% endif %}
   </ul>
     <table id="post_table" class="table">
         <thead>

--- a/tutor/matching/templates/matching/mypage_profile_update.html
+++ b/tutor/matching/templates/matching/mypage_profile_update.html
@@ -17,10 +17,10 @@
         <li class="nav-item">
             <a class="nav-link" href="{% url 'matching:mypage_tutor_session' %}">진행한 튜터 세션</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link active" href="{% url 'matching:mypage_profile' user.pk %}">닉네임 수정</a>
-        </li>
         {% endif %}
+        <li class="nav-item">
+            <a class="nav-link active" href="{% url 'matching:mypage_profile' user.pk %}">닉네임 수정</a>
+        </li>
     </ul>
     <br>
     <div class='edit_profile'>

--- a/tutor/matching/templates/matching/mypage_session.html
+++ b/tutor/matching/templates/matching/mypage_session.html
@@ -18,10 +18,10 @@
     <li class="nav-item">
       <a class="nav-link active">진행한 TA 세션</a>
     </li>
+    {% endif %}
     <li class="nav-item">
       <a class="nav-link" href="{% url 'matching:mypage_profile' user.pk %}">닉네임 수정</a>
     </li>
-    {% endif %}
   </ul>
     <table id="post_table" class="table">
         <thead>

--- a/tutor/matching/templates/matching/mypage_tutee_session.html
+++ b/tutor/matching/templates/matching/mypage_tutee_session.html
@@ -17,10 +17,10 @@
         <li class="nav-item">
             <a class="nav-link" href="{% url 'matching:mypage_tutor_session' %}">진행한 튜터 세션</a>
         </li>
+        {% endif %}
         <li class="nav-item">
           <a class="nav-link" href="{% url 'matching:mypage_profile' user.pk %}">닉네임 수정</a>
         </li>
-        {% endif %}
     </ul>
     <br>
     <table id="post_table" class="table">

--- a/tutor/matching/templates/matching/mypage_tutor_post.html
+++ b/tutor/matching/templates/matching/mypage_tutor_post.html
@@ -17,10 +17,10 @@
     <li class="nav-item">
       <a class="nav-link" href="{% url 'matching:mypage_tutor_session' %}">진행한 튜터 세션</a>
     </li>
+    {% endif %}
     <li class="nav-item">
       <a class="nav-link" href="{% url 'matching:mypage_profile' user.pk %}">닉네임 수정</a>
     </li>
-    {% endif %}
   </ul>
     <table id="post_table" class="table">
         <thead>


### PR DESCRIPTION
튜터인 조건문 안에서 닉네임 수정을 넣어서,
튜티의 경우 닉네임 수정 탭이 안보이는 에러가 있었다.
조건문 밖에 닉네임 수정 탭을 넣어서, 튜티의 경우에도
닉네임을 수정할 수 있도록 수정하였다.