### PR TITLE
Tutoring Start가 안되는 에러

### DIFF
--- a/tutor/tutor/settings.py
+++ b/tutor/tutor/settings.py
@@ -161,8 +161,8 @@ CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
-            # "hosts": [("redis://:AledmaThakd@172.17.0.2:6379/0")],
-            "hosts": [('127.0.0.1', 6379)],
+            "hosts": [("redis://:AledmaThakd@172.17.0.2:6379/0")],
+            # "hosts": [('127.0.0.1', 6379)],
         },
     },
 }


### PR DESCRIPTION
settings.py에 로컬과 서버의 redis환경설정이 달라서 로컬에서 개발하다가
잘못푸쉬하면 서버의 웹 소켓은 작동하지 않게 된다. 이를 해결할 근본적인
해결책이 필요하다.