### PR TITLE
Feat: 대기방 알림 설정 css 추가

### DIFF
--- a/tutor/matching/static/matching/js/notification-status.js
+++ b/tutor/matching/static/matching/js/notification-status.js
@@ -1,0 +1,21 @@
+(function(){
+  const perm_status = Notification.permission;
+  const $notification_status = document.getElementById("notification_container");
+  const alarm_announcement_url = `https://www.notion.so/20-09-21-9c716eb8d8224b7499a1fcf7e272865a`;
+  if(perm_status === 'granted'){
+    $notification_status.innerHTML = `
+    <div class='noti-success'>
+      <div class='noti__title'> 📥 알림이 설정되었습니다 </div>
+      <div class='noti__helptext'>튜터링이 시작되면 알림을 받으실 수 있습니다.</div>
+    </div>
+    `;
+  }else{
+    $notification_status.innerHTML =  `
+    <div class='noti-warning'>
+     <div class='noti__title'>🚨 알림 설정이 필요합니다 🚨</div>
+     <div class='noti__helptext'>튜터링이 시작되어도 알림을 받지 못하며, 화면이 안 옮겨질 수 있습니다.</div>
+     <div class='noti__link'><a href=${alarm_announcement_url} target="_blank">🔗알림 설정 바로가기</a></div>
+    </div>`
+    ;
+  }
+})();

--- a/tutor/matching/static/matching/notification.css
+++ b/tutor/matching/static/matching/notification.css
@@ -1,0 +1,25 @@
+#notification_container{
+  display: flex;
+  justify-content: center;
+  margin: 2% 10%;
+}
+.noti-warning{
+  padding: 1rem 2rem;
+  box-shadow: 0rem 0rem 0.2rem 0.01rem #C2443D;
+}
+.noti-success{
+  padding: 1rem 2rem;
+  box-shadow: 0rem 0rem 0.2rem 0.01rem #8755AA;
+}
+#notification_container > div{
+  text-align: center;
+}
+.noti__title{
+  font-weight: bold;
+}
+.noti__helptext{
+  font-size: small;
+}
+.noti__link{
+  background:#F4E1E2;
+}

--- a/tutor/matching/templates/matching/base.html
+++ b/tutor/matching/templates/matching/base.html
@@ -19,6 +19,7 @@
 		<link rel="stylesheet" type="text/css" href="{% static 'matching/search_bar.css' %}">
 		<link rel="stylesheet" type="text/css" href="{% static 'matching/session_report.css' %}">
 		<link rel="stylesheet" type="text/css" href="{% static 'matching/mypage.css' %}">
+		<link rel="stylesheet" type="text/css" href="{% static 'matching/notification.css' %}">
 		<script src="https://kit.fontawesome.com/f99623035e.js" crossorigin="anonymous"></script>
 
 		<style>
@@ -99,5 +100,6 @@
 		<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
 		<script type='module' src="{% static 'matching/js/index.js' %}" ></script>
 		<script type='module' src="{% static 'matching/js/main.js' %}" ></script>
+		<script type='module' src="{% static 'matching/js/notification-status.js' %}" ></script>
 	</body>
 </html>

--- a/tutor/matching/templates/matching/waiting_room.html
+++ b/tutor/matching/templates/matching/waiting_room.html
@@ -39,8 +39,7 @@
         <div id="waitingAfter">내 뒤 : <span id="waitingAfterNumber" class="inline">{{waitingAfterTutee.0}}</span></div>
       </div>
 
-      <div id="check_notification">
-        Notification 상태 : <p id="notification_status"></p>
+      <div id="notification_container">
       </div>
 
         <!-- t_rex_place -->
@@ -69,11 +68,6 @@
 
 <script>
 
-  const set_notification_status = () =>  {
-    let status = Notification.permission;
-    document.getElementById("notification_status").innerHTML = status;
-  }
-  set_notification_status();
 
   const send_notification = (nickname, message) => {
     if (!("Notification" in window)) {


### PR DESCRIPTION
## 구현사항
대기방에서 알림 설정 여부가 눈에 띄게 표시되지 않아서, 유저들이 알림 설정이 안되어있을 때,
튜터링 시작이 되어도 세션으로 들어가지지 않는 등 문제가 있었습니다. 
따라서 알림 여부를 눈에 띄는 스타일로 지정하였습니다.
대기방에서 알림이 설정되어있으면, 설정되어있다는 메시지를 줍니다.
default이거나 denied라면 알림을 설정해야 한다는 메시지와 알림 설정 링크를 알려줍니다.

## 알림 - granted 시
<img width="742" alt="스크린샷 2020-11-11 오후 11 53 27" src="https://user-images.githubusercontent.com/43772082/98826487-18c2e280-2479-11eb-9233-c6a9d4fe5c3b.png">

## 알림 - default, denied 시

<img width="809" alt="스크린샷 2020-11-11 오후 11 53 16" src="https://user-images.githubusercontent.com/43772082/98826473-12cd0180-2479-11eb-94fe-d3605c59bd57.png">

